### PR TITLE
Stamp CoT _flow-tags_ with COT_HOST_ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## AISCOT (Unreleased)
+
+- Stamp the CoT `_flow-tags_` with `COT_HOST_ID` when set (falls back to pytak's
+  default host id), so a functional source name appears in the CoT flow.
+
 ## AISCOT 7.1.4
 
 - Limit reported position precision to a maximum of 4 decimal places (~11 m).

--- a/src/aiscot/functions.py
+++ b/src/aiscot/functions.py
@@ -245,8 +245,9 @@ def ais_to_cot(
     cot.set("access", cot_access)
 
     _detail = cot.findall("detail")[0]
-    flowtags = _detail.findall("_flow-tags_")
-    detail.extend(flowtags)
+    # Stamp the flow tag with COT_HOST_ID (falls back to pytak's default host id
+    # when unset), rather than re-using gen_cot_xml's default-host-id flow tag.
+    detail.append(pytak.cot_flow_tags(cot_host_id or None))
     cot.remove(_detail)
     cot.append(detail)
 


### PR DESCRIPTION
## Summary

`ais_to_cot` built the CoT via `pytak.gen_cot_xml()` and then grafted that
event's default `_flow-tags_` (which uses pytak's `DEFAULT_HOST_ID` =
`pytak@<hostname>`) onto the detail. As a result, **`COT_HOST_ID` never reached
the CoT flow tags** — it only flowed into the remarks.

This regenerates the flow tag from `COT_HOST_ID` when set, falling back to
pytak's default host id otherwise:

- unset → `pytak-<hostname>-pytak` (unchanged, backward compatible)
- `COT_HOST_ID=snstac-pve-docker-aiscot` → `snstac-pve-docker-aiscot-pytak`

This matches the behavior adsbcot already adopted upstream (it passes
`flow_tag_host_id=cot_host_id` into `pytak.cot_detail`). Done here as a minimal
change that keeps the current `pytak>=5.4.0` pin.

## Testing

- `pytest` — 14 passed.
- Verified `ais_to_cot` output: flow tag carries `COT_HOST_ID` when set, and is
  unchanged when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)